### PR TITLE
Variant group product list:  add an edit link

### DIFF
--- a/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-cell.js
+++ b/src/Pim/Bundle/DataGridBundle/Resources/public/js/datagrid/cell/boolean-cell.js
@@ -12,7 +12,7 @@ function($, _, Backgrid) {
      */
     return Backgrid.BooleanCell.extend({
         /** @property {Boolean} */
-        listenRowClick: true,
+        listenRowClick: false,
 
         /**
          * @inheritDoc

--- a/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
+++ b/src/Pim/Bundle/EnrichBundle/Resources/config/datagrid/product_variant_group.yml
@@ -60,6 +60,18 @@ datagrid:
                 frontend_type: date
         properties:
             id: ~
+            edit_link:
+                type: url
+                route: pim_enrich_product_edit
+                params:
+                    - id
+                    - dataLocale
+        actions:
+            edit:
+                type:      navigate
+                label:     Edit
+                icon:      pencil
+                link:      edit_link
         sorters:
             columns:
                 in_group:


### PR DESCRIPTION
On the variant group product list page: (i.e. `/enrich/variant-group/105004/edit`)
add an edit link so we can quickly get to the product edit page.

Also: change bools in a datagrid only when clicked

Previously, any checkbox in a row would toggle when the row was clicked
This is a bit dangerous. All usages of booleans we've seen represent
membership to a group and they are usually important. Accidentally
changing them is bad.

Now, you have to click on the checkbox cell to change it, not just
anywhere on the row.