### PR TITLE
Attribute.unique: allow edit of Unique property

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/AttributeType/AbstractAttributeType.php
+++ b/src/Pim/Bundle/CatalogBundle/AttributeType/AbstractAttributeType.php
@@ -144,8 +144,8 @@ abstract class AbstractAttributeType implements AttributeTypeInterface
                 'name'      => 'unique',
                 'fieldType' => 'switch',
                 'options'   => [
-                    'disabled'  => true,
-                    'read_only' => true
+                    'disabled'  => false,
+                    'read_only' => false
                 ]
             ]
         ];

--- a/src/Pim/Bundle/CatalogBundle/AttributeType/DateType.php
+++ b/src/Pim/Bundle/CatalogBundle/AttributeType/DateType.php
@@ -36,9 +36,6 @@ class DateType extends AbstractAttributeType
             ]
         ];
 
-        $properties['unique']['options']['disabled'] = (bool) $attribute->getId();
-        $properties['unique']['options']['read_only'] = (bool) $attribute->getId();
-
         return $properties;
     }
 

--- a/src/Pim/Bundle/CatalogBundle/AttributeType/NumberType.php
+++ b/src/Pim/Bundle/CatalogBundle/AttributeType/NumberType.php
@@ -44,9 +44,6 @@ class NumberType extends AbstractAttributeType
             ]
         ];
 
-        $properties['unique']['options']['disabled'] = (bool) $attribute->getId();
-        $properties['unique']['options']['read_only'] = (bool) $attribute->getId();
-
         return $properties;
     }
 

--- a/src/Pim/Bundle/CatalogBundle/AttributeType/TextType.php
+++ b/src/Pim/Bundle/CatalogBundle/AttributeType/TextType.php
@@ -42,9 +42,6 @@ class TextType extends AbstractAttributeType
             ]
         ];
 
-        $properties['unique']['options']['disabled'] = (bool) $attribute->getId();
-        $properties['unique']['options']['read_only'] = (bool) $attribute->getId();
-
         return $properties;
     }
 

--- a/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
+++ b/src/Pim/Bundle/CatalogBundle/Resources/config/validation/attribute.yml
@@ -13,7 +13,6 @@ Pim\Bundle\CatalogBundle\Entity\Attribute:
                 - scopable
                 - localizable
                 - metricFamily
-                - unique
         - Pim\Component\Catalog\Validator\Constraints\ValidMetric:
             groups:
                 - pim_catalog_metric


### PR DESCRIPTION
We want to be able to make an attribute required to be unique after
it's been created. Enabling the change is easy.

Note: This doesn't enforce the initial state of uniqueness across all
existing values (that's up to you) but it does enforce it on all
further edits. For our purposes, that's fine.