### PR TITLE
Importing Prices: Merge currencies, don't replace

### DIFF
--- a/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
+++ b/src/Pim/Component/Catalog/Updater/Setter/PriceCollectionAttributeSetter.php
@@ -121,11 +121,6 @@ class PriceCollectionAttributeSetter extends AbstractAttributeSetter
 
         if (null === $value) {
             $value = $this->productBuilder->addOrReplaceProductValue($product, $attribute, $locale, $scope);
-        } else {
-            $prices = $value->getPrices();
-            foreach ($prices as $price) {
-                $price->setData(null);
-            }
         }
 
         foreach ($data as $price) {


### PR DESCRIPTION
When importing prices attribtues, merge new values with existing
currency values instead of erasing all values first.

Previously, the behavior would be:

current: [usd => 10, cad => 8]
import: [cad => 9]
result: [cad => 9]

After this change, the behavior is:

current: [usd => 10, cad => 8]
import: [cad => 9]
result: [usd => 10, cad => 9]

Akeneo claims this still passes all tests. As this seems a muchmore
sensible and safe approach to changing prices, we'll do it this way.

See discussion at
https://github.com/akeneo/pim-community-dev/issues/5059

See Issue:
https://github.com/iFixit/ifixit/issues/30591